### PR TITLE
1.1.1-non-text-content

### DIFF
--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -2,57 +2,119 @@ import * as React from "react"
 import { HTMLAttributes } from "react"
 
 export interface IconProps extends HTMLAttributes<HTMLSpanElement> {
-  name:
-    | "checkmark"
-    | "warning"
-    | "chevronDown"
-    | "chevronUp"
-    | "chevronRight"
-    | "chevronLeft"
-    | "xMark"
-    | "arrowUp"
-    | "arrowDown"
-    | "arrowRightwards"
-    | "arrowLeftwards"
-    | "arrowUpCircle"
-    | "arrowDownCircle"
-    | "bolt"
-    | "loupe"
+  name: Name
 }
 
 export const Icon = ({ name, ...props }: IconProps) => {
   switch (name) {
     case "checkmark":
-      return <span {...props}>&#10003;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#10003;
+        </span>
+      )
     case "warning":
-      return <span {...props}>&#1049087;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#1049087;
+        </span>
+      )
     case "chevronDown":
-      return <span {...props}>&#8964;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8964;
+        </span>
+      )
     case "chevronUp":
-      return <span {...props}>&#8963;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8963;
+        </span>
+      )
     case "chevronRight":
-      return <span {...props}>&#707;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#707;
+        </span>
+      )
     case "chevronLeft":
-      return <span {...props}>&#706;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#706;
+        </span>
+      )
     case "xMark":
-      return <span {...props}>&#10060;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#10060;
+        </span>
+      )
     case "arrowUp":
-      return <span {...props}>&#8593;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8593;
+        </span>
+      )
     case "arrowDown":
-      return <span {...props}>&#8595;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8595;
+        </span>
+      )
     case "arrowRightwards":
-      return <span {...props}>&#8594;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8594;
+        </span>
+      )
     case "arrowLeftwards":
-      return <span {...props}>&#8592;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#8592;
+        </span>
+      )
     case "arrowUpCircle":
-      return <span {...props}>&#1048694;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#1048694;
+        </span>
+      )
     case "arrowDownCircle":
-      return <span {...props}>&#1048696;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#1048696;
+        </span>
+      )
     case "bolt":
-      return <span {...props}>&#128498;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#128498;
+        </span>
+      )
     case "loupe":
-      return <span {...props}>&#1049259;</span>
+      return (
+        <span aria-hidden="true" {...props}>
+          &#1049259;
+        </span>
+      )
     default:
       return null
   }
 }
+
+type Name =
+  | "checkmark"
+  | "warning"
+  | "chevronDown"
+  | "chevronUp"
+  | "chevronRight"
+  | "chevronLeft"
+  | "xMark"
+  | "arrowUp"
+  | "arrowDown"
+  | "arrowRightwards"
+  | "arrowLeftwards"
+  | "arrowUpCircle"
+  | "arrowDownCircle"
+  | "bolt"
+  | "loupe"

--- a/src/components/content/Logo/Logo.tsx
+++ b/src/components/content/Logo/Logo.tsx
@@ -16,22 +16,14 @@ export const Logo = forwardRef<HTMLImageElement, LogoProps>(
     const colorMode = useColorMode()
     const logoDefault = () => {
       if (size === "small")
-        return (
-          <img src={logoDefaultSmall} alt="Einride Logo" ref={ref} {...props} />
-        )
-      return (
-        <img src={logoDefaultLarge} alt="Einride Logo" ref={ref} {...props} />
-      )
+        return <img src={logoDefaultSmall} alt="Einride" ref={ref} {...props} />
+      return <img src={logoDefaultLarge} alt="Einride" ref={ref} {...props} />
     }
 
     const logoInverse = () => {
       if (size === "small")
-        return (
-          <img src={logoInverseSmall} alt="Einride Logo" ref={ref} {...props} />
-        )
-      return (
-        <img src={logoInverseLarge} alt="Einride Logo" ref={ref} {...props} />
-      )
+        return <img src={logoInverseSmall} alt="Einride" ref={ref} {...props} />
+      return <img src={logoInverseLarge} alt="Einride" ref={ref} {...props} />
     }
 
     if (variant === "inverse" || (!variant && colorMode === "dark")) {


### PR DESCRIPTION
- fix: remove icons from accessibility tree as they are purely decorative ([source](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden))
- fix: remove redundant info from logo alt text ([source](https://www.deque.com/blog/great-alt-text-introduction/#:~:text=At%20a%20minimum%2C%20the%20alt,%E2%80%9CUser%20Testing%20%E2%80%93%20Home%E2%80%9D))