### PR TITLE
fix: add width to linear progress wrapper

### DIFF
--- a/src/components/charts/LinearProgress/LinearProgress.tsx
+++ b/src/components/charts/LinearProgress/LinearProgress.tsx
@@ -47,6 +47,8 @@ const Wrapper = styled.div`
   height: ${({ theme }) => theme.spacer}px;
   border-radius: ${({ theme }) => theme.spacer}px;
   position: relative;
+  /* Width needed to make sure component takes up full width in flex containers */
+  width: 100%;
 `
 
 const Value = styled.div<{

--- a/src/components/charts/StepProgress/StepProgress.tsx
+++ b/src/components/charts/StepProgress/StepProgress.tsx
@@ -46,6 +46,8 @@ export const StepProgress = forwardRef<HTMLDivElement, StepProgressProps>(
 const Wrapper = styled.div`
   display: flex;
   gap: ${({ theme }) => 0.5 * theme.spacer}px;
+  /* Width needed to make sure component takes up full width in flex containers */
+  width: 100%;
 `
 
 const Step = styled.div<{ color: ContentColor; completed: boolean }>`


### PR DESCRIPTION
making sure the child of linear progress always have space to calculate percentage from