### PR TITLE
feat: make inputs without labels rounded

### DIFF
--- a/src/components/controls/inputs/TextInput/TextInput.tsx
+++ b/src/components/controls/inputs/TextInput/TextInput.tsx
@@ -1,3 +1,4 @@
+import styled from "@emotion/styled"
 import {
   ChangeEvent,
   ElementType,
@@ -31,7 +32,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     return (
       <>
-        <BaseInput icon={getStatusIcon(theme, status)} {...props} ref={ref} />
+        <StyledBaseInput
+          icon={getStatusIcon(theme, status)}
+          {...props}
+          ref={ref}
+        />
         {message && (
           <Caption color={getMessageColor(status)}>{message}</Caption>
         )}
@@ -41,6 +46,10 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 )
 
 type Status = "success" | "fail" | "neutral"
+
+const StyledBaseInput = styled(BaseInput)`
+  border-radius: ${({ theme }) => 3 * theme.spacer}px;
+`
 
 const getStatusIcon = (theme: Theme, status?: Status) => {
   switch (status) {

--- a/src/components/controls/selects/DefaultDropdownSelect/DefaultDropdownSelect.tsx
+++ b/src/components/controls/selects/DefaultDropdownSelect/DefaultDropdownSelect.tsx
@@ -77,7 +77,7 @@ const StyledSelect = styled.select<{ isFullWidth?: boolean }>`
   padding: 12px 16px;
   padding-right: ${({ theme }) => 6 * theme.spacer}px;
   border: unset;
-  border-radius: 2px;
+  border-radius: ${({ theme }) => 3 * theme.spacer}px;
   cursor: pointer;
   appearance: none;
 


### PR DESCRIPTION
Decided together with Rui that all input components without labels should have rounded corders. This should make it possible for you to use `DefaultDropdownSelect` out of the box in Explore @jenseo! 