### PR TITLE
feat: add title to popover

### DIFF
--- a/src/components/views/Popover/Popover.stories.tsx
+++ b/src/components/views/Popover/Popover.stories.tsx
@@ -37,3 +37,8 @@ const Template: Story<PopoverProps> = (args) => {
 
 export const Default = Template.bind({})
 Default.args = {}
+
+export const WithTitle = Template.bind({})
+WithTitle.args = {
+  title: "Page name",
+}

--- a/src/components/views/Popover/Popover.tsx
+++ b/src/components/views/Popover/Popover.tsx
@@ -9,13 +9,15 @@ import { AnimatePresence, HTMLMotionProps, motion } from "framer-motion"
 import { forwardRef, ReactNode, useEffect } from "react"
 import { PrimaryButton } from "../../controls/buttons/PrimaryButton/PrimaryButton"
 import { SecondaryButton } from "../../controls/buttons/SecondaryButton/SecondaryButton"
+import { Paragraph } from "../../typography/Paragraph/Paragraph"
 
-export interface PopoverProps extends HTMLMotionProps<"div"> {
+export interface PopoverProps extends Omit<HTMLMotionProps<"div">, "title"> {
   children: ReactNode
   closeHandler: () => void
   isOpen: boolean
   primaryAction?: PopoverAction
   secondaryAction?: PopoverAction
+  title?: ReactNode
 }
 
 export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
@@ -26,6 +28,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       isOpen,
       primaryAction,
       secondaryAction,
+      title,
       ...props
     },
     ref,
@@ -50,13 +53,12 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     return (
       <AnimatePresence>
         {isOpen && (
-          <>
-            <Overlay
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              initial={{ opacity: 0 }}
-              onClick={closeHandler}
-            />
+          <Overlay
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            initial={{ opacity: 0 }}
+            onClick={closeHandler}
+          >
             <Wrapper
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
@@ -65,6 +67,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
               ref={mergedRef}
             >
               <MediumLargeNav>
+                {title ? <Paragraph>{title}</Paragraph> : <div />}
                 <Actions>
                   {secondaryAction && (
                     <SecondaryButton onClick={secondaryAction.handler}>
@@ -95,7 +98,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
                 )}
               </SmallNav>
             </Wrapper>
-          </>
+          </Overlay>
         )}
       </AnimatePresence>
     )
@@ -115,47 +118,46 @@ const Overlay = styled(motion.div)`
   left: 0;
   background: ${({ theme }) => theme.colors.background.focus};
   z-index: 1;
+  display: flex;
+  justify-content: center;
 `
 
 const Wrapper = styled(motion.div)`
-  position: fixed;
-  top: ${({ theme }) => 10 * theme.spacer}px;
-  right: ${({ theme }) => 2 * theme.spacer}px;
-  bottom: ${({ theme }) => 2 * theme.spacer}px;
-  left: ${({ theme }) => 2 * theme.spacer}px;
+  margin-top: ${({ theme }) => 10 * theme.spacer}px;
+  margin-right: ${({ theme }) => 2 * theme.spacer}px;
+  margin-bottom: ${({ theme }) => 2 * theme.spacer}px;
+  margin-left: ${({ theme }) => 2 * theme.spacer}px;
   background: ${({ theme }) => theme.colors.background.primaryElevated};
   border-radius: ${({ theme }) => 2 * theme.spacer}px;
+  width: calc(100vw - ${({ theme }) => 2 * theme.spacer}px);
   z-index: 2;
 
   @media ${({ theme }) => theme.mediaQueries.md} {
-    top: 10vh;
-    right: calc(25% - 5px);
-    bottom: 10vh;
-    left: calc(25% - 5px);
-  }
-
-  @media ${({ theme }) => theme.mediaQueries.lg} {
-    top: 10vh;
-    right: calc(25% - 5px);
-    bottom: 10vh;
-    left: calc(25% - 5px);
+    width: max(
+      50vw,
+      ${({ theme }) => theme.breakpoints.md - 2 * theme.spacer}px
+    );
+    margin-top: 10vh;
+    margin-bottom: 10vh;
   }
 `
 
 const MediumLargeNav = styled.nav`
-  display: none;
-
-  @media ${({ theme }) => theme.mediaQueries.md} {
-    display: block;
-    padding: ${({ theme }) => 2 * theme.spacer}px;
-    padding-bottom: 0;
-  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${({ theme }) => 2 * theme.spacer}px;
+  padding-bottom: 0;
 `
 
 const Actions = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  gap: ${({ theme }) => 2 * theme.spacer}px;
+  display: none;
+
+  @media ${({ theme }) => theme.mediaQueries.md} {
+    display: flex;
+    justify-content: flex-end;
+    gap: ${({ theme }) => 2 * theme.spacer}px;
+  }
 `
 
 const Content = styled.div`
@@ -164,9 +166,9 @@ const Content = styled.div`
 
 const SmallNav = styled.nav`
   position: absolute;
-  right: ${({ theme }) => 2 * theme.spacer}px;
-  left: ${({ theme }) => 2 * theme.spacer}px;
-  bottom: ${({ theme }) => 3 * theme.spacer}px;
+  right: ${({ theme }) => 4 * theme.spacer}px;
+  left: ${({ theme }) => 4 * theme.spacer}px;
+  bottom: ${({ theme }) => 5 * theme.spacer}px;
   display: flex;
   flex-direction: column;
   gap: ${({ theme }) => 2 * theme.spacer}px;


### PR DESCRIPTION
This adds two things, the possibility to provide a title to the popover as a "full width" scaling for the responsive modes (no idea if this is an acceptable change from design or not)

![popover_before mov](https://user-images.githubusercontent.com/183679/162986350-a23fd690-2388-442d-9298-1b71a75aff81.gif)
![popover_after mov](https://user-images.githubusercontent.com/183679/162986886-72cbaae5-f8ca-44ab-b457-4420c9018378.gif)

