### PR TITLE
chore: rely on base input icon slots to simplify input components

### DIFF
--- a/src/components/controls/inputs/BaseInput/BaseInput.tsx
+++ b/src/components/controls/inputs/BaseInput/BaseInput.tsx
@@ -1,26 +1,108 @@
 import styled from "@emotion/styled"
-import { ElementType, forwardRef, InputHTMLAttributes, ReactNode } from "react"
+import { useUuid } from "@mantine/hooks"
+import {
+  ElementType,
+  forwardRef,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+  ReactNode,
+} from "react"
+import { ContentColor } from "../../../../lib/theme/types"
+import { Caption } from "../../../typography/Caption/Caption"
 
 export interface BaseInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Effective element used. */
   as?: ElementType
-  icon?: ReactNode
+
+  /** Input label, displayed before input. */
+  label?: ReactNode
+
+  /** Props passed to label element. */
+  labelProps?: LabelHTMLAttributes<HTMLLabelElement>
+
+  /** Icon shown on the left side. */
+  leftIcon?: ReactNode
+
+  /** Message shown below input field. Can be used together with `status` to show a success or error message. */
+  message?: ReactNode
+
+  /** Icon shown on the right side. */
+  rightIcon?: ReactNode
+
+  /**  Default is `neutral`. */
+  status?: Status | undefined
+
+  /** Props passed to root element. */
+  wrapperProps?: HTMLAttributes<HTMLDivElement>
 }
 
-export const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(({ icon, ...props }, ref) => {
-  return (
-    <ContentWrapper>
-      <StyledInput {...props} ref={ref} />
-      <IconWrapper>{icon}</IconWrapper>
-    </ContentWrapper>
-  )
-})
+export const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
+  ({ label, labelProps, leftIcon, message, rightIcon, status, wrapperProps, ...props }, ref) => {
+    const id = useUuid()
 
-const ContentWrapper = styled.div`
-  position: relative;
-  display: block;
+    return (
+      <Wrapper {...wrapperProps}>
+        {label && (
+          <StyledLabel {...labelProps} htmlFor={id}>
+            {label}
+          </StyledLabel>
+        )}
+        <InputWrapper>
+          {leftIcon && <LeftIconWrapper>{leftIcon}</LeftIconWrapper>}
+          <StyledInput
+            {...props}
+            label={!!label}
+            leftIcon={!!leftIcon}
+            rightIcon={!!rightIcon}
+            id={id}
+            ref={ref}
+          />
+          {rightIcon && <RightIconWrapper>{rightIcon}</RightIconWrapper>}
+        </InputWrapper>
+        {message && <Caption color={getMessageColor(status)}>{message}</Caption>}
+      </Wrapper>
+    )
+  },
+)
+
+const Wrapper = styled.div``
+
+const StyledLabel = styled.label`
+  display: inline-block;
+  font-family: ${({ theme }) => theme.fonts.body};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-weight: ${({ theme }) => theme.fontWeights.book};
+  line-height: calc(4 / 3);
+  margin-top: 5px;
+  margin-bottom: 3px;
+  color: ${({ theme }) => theme.colors.content.secondary};
 `
 
-const StyledInput = styled.input`
+const InputWrapper = styled.div`
+  position: relative;
+`
+
+const IconWrapper = styled.div`
+  position: absolute;
+  top: ${({ theme }) => 1.5 * theme.spacer}px;
+  bottom: ${({ theme }) => 1.5 * theme.spacer}px;
+  height: ${({ theme }) => 3 * theme.spacer}px;
+  width: ${({ theme }) => 3 * theme.spacer}px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const LeftIconWrapper = styled(IconWrapper)`
+  left: ${({ theme }) => theme.spacer}px;
+`
+
+const RightIconWrapper = styled(IconWrapper)`
+  right: ${({ theme }) => theme.spacer}px;
+`
+
+const StyledInput = styled.input<{ label: boolean; leftIcon: boolean; rightIcon: boolean }>`
   font-family: ${({ theme }) => theme.fonts.body};
   font-size: ${({ theme }) => theme.fontSizes.md};
   font-weight: ${({ theme }) => theme.fontWeights.book};
@@ -29,9 +111,11 @@ const StyledInput = styled.input`
   color: ${({ theme }) => theme.colors.content.primary};
   width: 100%;
   display: block;
-  padding: 12px 16px;
-  border: unset;
-  border-radius: ${({ theme }) => theme.borderRadii.sm};
+  padding-block: ${({ theme }) => 1.5 * theme.spacer}px;
+  padding-inline: ${({ theme }) => 2 * theme.spacer}px;
+  border-radius: ${({ label, theme }) => (label ? theme.borderRadii.sm : theme.borderRadii.xl)};
+  ${({ leftIcon, theme }) => leftIcon && `padding-left: ${4.5 * theme.spacer}px`};
+  ${({ rightIcon, theme }) => rightIcon && `padding-right: ${6 * theme.spacer}px`};
 
   &:focus {
     box-shadow: 0px 0px 0px 1px ${({ theme }) => theme.colors.border.selected} inset;
@@ -51,8 +135,15 @@ const StyledInput = styled.input`
   }
 `
 
-const IconWrapper = styled.span`
-  position: absolute;
-  top: ${({ theme }) => 1.5 * theme.spacer}px;
-  right: ${({ theme }) => 2 * theme.spacer}px;
-`
+const getMessageColor = (status: Status | undefined): ContentColor => {
+  switch (status) {
+    case "success":
+      return "positive"
+    case "fail":
+      return "negative"
+    default:
+      return "secondary"
+  }
+}
+
+export type Status = "success" | "fail" | "neutral"

--- a/src/components/controls/inputs/LabelTextInput/LabelTextInput.tsx
+++ b/src/components/controls/inputs/LabelTextInput/LabelTextInput.tsx
@@ -41,7 +41,7 @@ export const LabelTextInput = forwardRef<HTMLInputElement, LabelTextInputProps>(
         <StyledLabel htmlFor={uuid} style={labelStyles}>
           {label} {required && " (required)"}
         </StyledLabel>
-        <BaseInput id={uuid} icon={getStatusIcon(theme, status)} {...props} ref={ref} />
+        <BaseInput id={uuid} rightIcon={getStatusIcon(theme, status)} {...props} ref={ref} />
         {message && <Caption color={getMessageColor(status)}>{message}</Caption>}
       </Wrapper>
     )

--- a/src/components/controls/inputs/SearchInput/SearchInput.stories.tsx
+++ b/src/components/controls/inputs/SearchInput/SearchInput.stories.tsx
@@ -17,9 +17,3 @@ export const Default = Template.bind({})
 Default.args = {
   placeholder: "Search...",
 }
-
-export const Controlled = Template.bind({})
-Controlled.args = {
-  ...Default.args,
-  value: "",
-}

--- a/src/components/controls/inputs/SearchInput/SearchInput.tsx
+++ b/src/components/controls/inputs/SearchInput/SearchInput.tsx
@@ -1,63 +1,41 @@
-import styled from "@emotion/styled"
-import { ElementType, forwardRef, InputHTMLAttributes } from "react"
+import { ElementType, forwardRef, HTMLAttributes, InputHTMLAttributes } from "react"
 import { Icon } from "../../../content/Icon/Icon"
 import { BaseInput } from "../BaseInput/BaseInput"
 
 export interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Accessible name, required when `label` is not provided. */
   "aria-label": string
+
+  /** Effective element used. */
   as?: ElementType
+
+  /** `onChange` handler. */
   onInputChange?: (input: string) => void
-  placeholder: string
+
+  /** Controlled input value. */
   value?: string
+
+  /** Props passed to root element. */
+  wrapperProps?: HTMLAttributes<HTMLDivElement>
 }
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
   ({ value, onInputChange, ...props }, ref) => {
     return (
-      <Wrapper>
-        <StyledInput
-          value={value}
-          onChange={(e) => onInputChange?.(e.target.value)}
-          {...props}
-          ref={ref}
-        />
-        <LoupeIcon name="loupe" color="primary" />
-        {value && (
-          <ClearButton onClick={() => onInputChange?.("")}>
-            <Icon name="xMark" color="primary" />
-          </ClearButton>
-        )}
-      </Wrapper>
+      <BaseInput
+        {...props}
+        leftIcon={<Icon name="loupe" />}
+        onChange={(e) => onInputChange?.(e.target.value)}
+        rightIcon={
+          value?.length ? (
+            <button type="button" onClick={() => onInputChange?.("")}>
+              <Icon name="xMark" color="primary" />
+            </button>
+          ) : null
+        }
+        value={value}
+        ref={ref}
+      />
     )
   },
 )
-
-const Wrapper = styled.div`
-  position: relative;
-  width: 100%;
-`
-
-const StyledInput = styled(BaseInput)`
-  padding-right: ${({ theme }) => 5 * theme.spacer}px;
-  padding-left: ${({ theme }) => 5 * theme.spacer}px;
-  border-radius: ${({ theme }) => theme.borderRadii.xl};
-`
-
-const LoupeIcon = styled(Icon)`
-  position: absolute;
-  top: ${({ theme }) => 1.5 * theme.spacer}px;
-  height: ${({ theme }) => 3 * theme.spacer}px;
-  left: ${({ theme }) => 2 * theme.spacer}px;
-  font-size: ${({ theme }) => theme.fontSizes.md};
-  font-weight: ${({ theme }) => theme.fontWeights.book};
-`
-
-const ClearButton = styled.button`
-  position: absolute;
-  top: ${({ theme }) => 1.5 * theme.spacer}px;
-  height: ${({ theme }) => 3 * theme.spacer}px;
-  right: ${({ theme }) => theme.spacer}px;
-  padding: 0 ${({ theme }) => theme.spacer}px;
-  font-size: ${({ theme }) => theme.fontSizes.md};
-  font-weight: ${({ theme }) => theme.fontWeights.book};
-`

--- a/src/components/controls/inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/controls/inputs/TextInput/TextInput.stories.tsx
@@ -15,25 +15,25 @@ const Template: Story<TextInputProps> = (args) => <TextInput {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
+  "aria-label": "Label",
   placeholder: "Placeholder...",
+}
+
+export const Label = Template.bind({})
+Label.args = {
+  label: "Label",
 }
 
 export const Positive = Template.bind({})
 Positive.args = {
-  ...Default.args,
+  ...Label.args,
   message: "Confirmation message.",
   status: "success",
 }
 
 export const Negative = Template.bind({})
 Negative.args = {
-  ...Default.args,
+  ...Label.args,
   message: "Error message.",
   status: "fail",
-}
-
-export const Controlled = Template.bind({})
-Controlled.args = {
-  ...Default.args,
-  value: "",
 }

--- a/src/components/controls/inputs/TextInput/TextInput.tsx
+++ b/src/components/controls/inputs/TextInput/TextInput.tsx
@@ -1,68 +1,77 @@
 import styled from "@emotion/styled"
 import {
-  ChangeEvent,
   ElementType,
-  FocusEvent,
   forwardRef,
+  HTMLAttributes,
   InputHTMLAttributes,
+  LabelHTMLAttributes,
   ReactNode,
 } from "react"
-import { useTheme } from "../../../../hooks/useTheme"
-import { Theme } from "../../../../lib/theme/theme"
-import { ContentColor } from "../../../../lib/theme/types"
 import { Icon } from "../../../content/Icon/Icon"
-import { Caption } from "../../../typography/Caption/Caption"
-import { BaseInput } from "../BaseInput/BaseInput"
+import { BaseInput, Status } from "../BaseInput/BaseInput"
 
-export interface TextInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  "aria-label": string
+interface TextInputBaseProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Effective element used. */
   as?: ElementType
+
+  /** Message shown below input field. Can be used together with `status` to show a success or error message. */
   message?: ReactNode
-  onBlur?: (e: FocusEvent<HTMLInputElement>) => void
-  onChange?: (e: ChangeEvent<HTMLInputElement>) => void
-  placeholder: string
-  /** Default: "neutral" */
-  status?: Status
+
+  /**  Default is `neutral`. */
+  status?: Status | undefined
+
+  /** Controlled input value. */
   value?: string
+
+  /** Props passed to root element. */
+  wrapperProps?: HTMLAttributes<HTMLDivElement>
 }
+
+interface TextInputWithLabelProps {
+  /** Input label, displayed before input. */
+  label?: ReactNode
+
+  /** Props passed to label element. */
+  labelProps?: LabelHTMLAttributes<HTMLLabelElement>
+}
+
+interface TextInputWithoutLabelProps {
+  /** Accessible name, required when `label` is not provided. */
+  "aria-label": string
+}
+
+export type TextInputProps = TextInputBaseProps &
+  (TextInputWithLabelProps | TextInputWithoutLabelProps)
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
   ({ message, status, ...props }, ref) => {
-    const theme = useTheme()
-
     return (
-      <>
-        <StyledBaseInput icon={getStatusIcon(theme, status)} {...props} ref={ref} />
-        {message && <Caption color={getMessageColor(status)}>{message}</Caption>}
-      </>
+      <BaseInput
+        {...props}
+        message={message}
+        rightIcon={getStatusIcon(status)}
+        status={status}
+        ref={ref}
+      />
     )
   },
 )
 
-type Status = "success" | "fail" | "neutral"
-
-const StyledBaseInput = styled(BaseInput)`
-  border-radius: ${({ theme }) => theme.borderRadii.xl};
-`
-
-const getStatusIcon = (theme: Theme, status?: Status): JSX.Element | null => {
+const getStatusIcon = (status?: Status): JSX.Element | null => {
   switch (status) {
     case "success":
-      return <Icon name="checkmark" style={{ color: theme.colors.content.positive }} />
+      return <PositiveIcon name="checkmark" />
     case "fail":
-      return <Icon name="warning" style={{ color: theme.colors.content.negative }} />
+      return <NegativeIcon name="warning" />
     default:
       return null
   }
 }
 
-const getMessageColor = (status: Status | undefined): ContentColor => {
-  switch (status) {
-    case "success":
-      return "positive"
-    case "fail":
-      return "negative"
-    default:
-      return "secondary"
-  }
-}
+const PositiveIcon = styled(Icon)`
+  color: ${({ theme }) => theme.colors.content.positive};
+`
+
+const NegativeIcon = styled(Icon)`
+  color: ${({ theme }) => theme.colors.content.negative};
+`


### PR DESCRIPTION
Preferring many components with simple props over few components with complex props has served us well. However, making `<TextInput>` and `<LabelTextInput>` separate, even though the label and the `border-radius` are the only differences, seems like it causes more overhead than it saves.

I'm preparing supporting `label` in the `<TextInput>` component here, so that we can deprecate or remove `<LabelTextInput>` in the next major.