### PR TITLE
chore: do not pass color prop to component

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@einride/hooks": "1.7.0",
+    "@emotion/is-prop-valid": "1.2.0",
     "@mantine/hooks": "5.4.0",
     "lodash.merge": "4.6.2"
   },

--- a/src/components/typography/Caption/Caption.tsx
+++ b/src/components/typography/Caption/Caption.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.p<StyledTextProps>`
+const StyledText = styled("p", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes.sm};

--- a/src/components/typography/Link/Link.tsx
+++ b/src/components/typography/Link/Link.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ComponentPropsWithoutRef, ElementType, ReactNode } from "react"
 import { ContentColor, Font, Theme } from "../../../lib/theme/types"
@@ -24,7 +25,14 @@ export const Link = <C extends ElementType>({
 
 type Color = Extract<ContentColor, "primary" | "secondary">
 
-const StyledAnchor = styled.a<{ color: Color; font: Font }>`
+interface StyledAnchorProps {
+  color: Color
+  font: Font
+}
+
+const StyledAnchor = styled("a", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledAnchorProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   cursor: pointer;

--- a/src/components/typography/MegaTitle/MegaTitle.tsx
+++ b/src/components/typography/MegaTitle/MegaTitle.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.h1<StyledTextProps>`
+const StyledText = styled("h1", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes["3xl"]};

--- a/src/components/typography/Paragraph/Paragraph.tsx
+++ b/src/components/typography/Paragraph/Paragraph.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.p<StyledTextProps>`
+const StyledText = styled("p", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes.md};

--- a/src/components/typography/Title1/Title1.tsx
+++ b/src/components/typography/Title1/Title1.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.h1<StyledTextProps>`
+const StyledText = styled("h1", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes["2xl"]};

--- a/src/components/typography/Title2/Title2.tsx
+++ b/src/components/typography/Title2/Title2.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.h2<StyledTextProps>`
+const StyledText = styled("h2", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes.xl};

--- a/src/components/typography/Title3/Title3.tsx
+++ b/src/components/typography/Title3/Title3.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ElementType, forwardRef, HTMLAttributes, ReactNode } from "react"
 import { ContentColor, Font } from "../../../lib/theme/types"
@@ -31,7 +32,9 @@ interface StyledTextProps {
   font: Font
 }
 
-const StyledText = styled.h3<StyledTextProps>`
+const StyledText = styled("h3", {
+  shouldForwardProp: (prop) => isPropValid(prop) && prop !== "color",
+})<StyledTextProps>`
   color: ${({ color, theme }) => theme.colors.content[color]};
   font-family: ${({ font, theme }) => theme.fonts[font]};
   font-size: ${({ theme }) => theme.fontSizes.lg};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1399,19 +1399,19 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
+"@emotion/is-prop-valid@1.2.0", "@emotion/is-prop-valid@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+
 "@emotion/is-prop-valid@^0.8.2":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
   dependencies:
     "@emotion/memoize" "0.7.4"
-
-"@emotion/is-prop-valid@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
-  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
-  dependencies:
-    "@emotion/memoize" "^0.8.0"
 
 "@emotion/memoize@0.7.4":
   version "0.7.4"


### PR DESCRIPTION
Right now, the `color` prop is leaking to the DOM, which is shouldn't do.

![image](https://user-images.githubusercontent.com/44197016/191257088-68644e4f-f682-476c-8162-5932b051d60f.png)

Using `shouldForwardProp` fixes that.