### PR TITLE
fix: allow node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "dist"
   ],
   "engines": {
-    "node": "16"
+    "node": "16 || 18"
   },
   "author": "Filip Tammergård",
   "publishConfig": {


### PR DESCRIPTION
Evolve needs it to solve CI problems related to commit-lint.
