### PR TITLE
fix(UserAccessPoint): use elevated background color

### DIFF
--- a/src/components/content/UserAccessPoint/UserAccessPoint.tsx
+++ b/src/components/content/UserAccessPoint/UserAccessPoint.tsx
@@ -60,7 +60,7 @@ type Status = "default" | "notification" | "no-user"
 
 const Button = styled.button<{ status: Status }>`
   position: relative;
-  background: ${({ theme }) => theme.colors.background.secondary};
+  background: ${({ theme }) => theme.colors.background.secondaryElevated};
   border-radius: ${({ theme }) => theme.borderRadii.xl};
   align-items: center;
   display: flex;


### PR DESCRIPTION
To prevent this:
![image](https://user-images.githubusercontent.com/44197016/208093658-8a7ac11b-2dda-415c-8e49-ba1ec1c9d68e.png)
