### PR TITLE
feat(Tooltip): enable width prop

### DIFF
--- a/src/components/content/Tooltip/Tooltip.stories.tsx
+++ b/src/components/content/Tooltip/Tooltip.stories.tsx
@@ -101,6 +101,19 @@ Table.play = async ({ canvasElement }) => {
   await expect(tooltipTrigger).toHaveAttribute("data-state", "closed")
 }
 
+export const Multiline = Template.bind({})
+Multiline.args = {
+  children: "Tooltip trigger",
+  content:
+    "Some really really really really really really really really really really really really really really really really really really really really really really really long tooltip content.",
+  width: 50,
+}
+Multiline.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const tooltipTrigger = canvas.getByRole("button", { name: "Tooltip trigger" })
+  await expect(tooltipTrigger).toHaveAttribute("data-state", "closed")
+}
+
 export const Mouse = Template.bind({})
 Mouse.args = {
   ...Basic.args,

--- a/src/components/content/Tooltip/Tooltip.tsx
+++ b/src/components/content/Tooltip/Tooltip.tsx
@@ -3,7 +3,9 @@ import styled from "@emotion/styled"
 import * as RadixTooltip from "@radix-ui/react-tooltip"
 import { ReactNode } from "react"
 import { useTheme } from "../../../hooks/useTheme"
+import { Width } from "../../../lib/theme/props"
 import { zIndex } from "../../../lib/zIndex"
+import { Box } from "../../layout/Box/Box"
 
 interface TooltipProps {
   /** Tooltip components. */
@@ -20,6 +22,9 @@ interface TooltipProps {
 
   /** Merges the original component props with the props of the supplied component and change the underlying DOM node. */
   triggerAsChild?: boolean
+
+  /** Width of the tooltip. */
+  width?: Width
 }
 
 export const Tooltip = ({
@@ -39,8 +44,8 @@ export const Tooltip = ({
           {children}
         </StyledTooltipTrigger>
         <RadixTooltip.Portal>
-          <StyledTooltipContent collisionPadding={2 * theme.spacer} sideOffset={5} {...props}>
-            {content}
+          <StyledTooltipContent collisionPadding={2 * theme.spacer} sideOffset={5}>
+            <Box {...props}>{content}</Box>
           </StyledTooltipContent>
         </RadixTooltip.Portal>
       </RadixTooltip.Root>

--- a/src/components/layout/Box/Box.tsx
+++ b/src/components/layout/Box/Box.tsx
@@ -1,3 +1,4 @@
+import isPropValid from "@emotion/is-prop-valid"
 import styled from "@emotion/styled"
 import { ComponentPropsWithoutRef, forwardRef } from "react"
 import {
@@ -208,7 +209,11 @@ interface WrapperProps {
   width?: Width
 }
 
-const Wrapper = styled.div<WrapperProps>`
+const validPropsToAvoidForwarding = ["height", "width"] // valid HTML attributes that should not be forwarded
+
+const Wrapper = styled("div", {
+  shouldForwardProp: (prop) => isPropValid(prop) && !validPropsToAvoidForwarding.includes(prop),
+})<WrapperProps>`
   align-items: ${({ alignItems }) => alignItems};
   background: ${({ background, theme }) => background && getBackground(background, theme)};
   block-size: ${({ blockSize, theme }) => blockSize && getSpacing(blockSize, theme)};


### PR DESCRIPTION
Makes multiline tooltips possible:
![image](https://user-images.githubusercontent.com/44197016/212041209-a239fa22-dbda-416a-86aa-a9c619324fd1.png)
