### PR TITLE
chore: add chromatic publish summary

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,7 @@ jobs:
   chromatic-deployment:
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    name: Chromatic deployment
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,8 +23,13 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Publish to Chromatic
+        id: chromatic
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
+
+      - name: Publish Summary
+        run: |
+          echo "Storybook Preview: ${{steps.chromatic.outputs.storybookUrl}}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
With this, you can go to Checks -> Chromatic in a PR and you'll see a Chromatic deployment summary like this, where you can get a link to the Chromatic build for the PR:

![image](https://user-images.githubusercontent.com/44197016/213130182-92bc4d7f-9b66-41f1-a7c8-d4d381dd280a.png)
