### PR TITLE
fix(Menu): map isOpen correctly to the Radix UI open prop

### DIFF
--- a/src/components/menus/Menu/Menu.tsx
+++ b/src/components/menus/Menu/Menu.tsx
@@ -15,6 +15,13 @@ interface MenuProps {
   onOpenChange?: (open: boolean) => void
 }
 
-export const Menu = ({ children, ...props }: MenuProps): JSX.Element => {
-  return <DropdownMenu.Root {...props}>{children}</DropdownMenu.Root>
+export const Menu = ({ children, isOpen, ...props }: MenuProps): JSX.Element => {
+  return (
+    <DropdownMenu.Root
+      {...(typeof isOpen === "boolean" && { open: isOpen })} // TODO: Change to `open` in next major?
+      {...props}
+    >
+      {children}
+    </DropdownMenu.Root>
+  )
 }


### PR DESCRIPTION
Discovered that `isOpen` doesn't do anything, since Radix UI takes `open`. 

Can't do plain `open={isOpen}`, since `open` is typed as optional `boolean` and doesn't accept `undefined`. 