### PR TITLE
chore: add table view template

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@einride/hooks": "1.7.4",
     "@emotion/is-prop-valid": "1.2.0",
+    "@faker-js/faker": "7.6.0",
     "@mantine/core": "5.9.4",
     "@mantine/dates": "5.9.4",
     "@mantine/hooks": "5.9.4",

--- a/src/templates/TableView.stories.tsx
+++ b/src/templates/TableView.stories.tsx
@@ -1,0 +1,100 @@
+import { faker } from "@faker-js/faker"
+import { Story as StoryType } from "@storybook/react"
+import { Icon } from "../components/content/Icon/Icon"
+import { IconButton } from "../components/controls/buttons/IconButton/IconButton"
+import { PrimaryButton } from "../components/controls/buttons/PrimaryButton/PrimaryButton"
+import { Box } from "../components/layout/Box/Box"
+import { Group } from "../components/layout/Group/Group"
+import { VerticalSpacing } from "../components/layout/VerticalSpacing/VerticalSpacing"
+import { Menu } from "../components/menus/Menu/Menu"
+import { MenuContent } from "../components/menus/Menu/MenuContent"
+import { MenuItem } from "../components/menus/Menu/MenuItem"
+import { MenuTrigger } from "../components/menus/Menu/MenuTrigger"
+import { Table } from "../components/table/Table/Table"
+import { Tbody } from "../components/table/Tbody/Tbody"
+import { Td } from "../components/table/Td/Td"
+import { Th } from "../components/table/Th/Th"
+import { Thead } from "../components/table/Thead/Thead"
+import { Tr } from "../components/table/Tr/Tr"
+import { Text } from "../components/typography/Text/Text"
+
+export default {
+  title: "Templates",
+  decorators: [
+    (Story: StoryType) => (
+      // Resetting margin from global decorator. Should be remove the global decorator, or can it be used conditionally?
+      <Box marginBlockStart={-3}>
+        <Story />
+      </Box>
+    ),
+  ],
+}
+
+function createRandomUser(): { id: string; name: string; email: string; role: string } {
+  return {
+    id: faker.datatype.uuid(),
+    name: faker.name.fullName(),
+    email: faker.internet.email(),
+    role: faker.helpers.arrayElement(["Owner", "Admin", "Editor", "Viewer"]),
+  }
+}
+
+const users = Array.from({ length: 20 }).map(() => createRandomUser())
+
+export const TableView = (): JSX.Element => (
+  <Box>
+    <Navbar />
+    <VerticalSpacing />
+    <Text as="h1" variant="titleLg">
+      Title
+    </Text>
+    <Text as="h2" color="secondary" variant="titleLg">
+      Subtitle
+    </Text>
+    <VerticalSpacing size="lg" />
+    <Table>
+      <Thead>
+        <Tr>
+          <Th scope="row">User</Th>
+          <Th scope="row">Email</Th>
+          <Th scope="row">Role</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {users.map((user) => (
+          <Tr key={user.id}>
+            <Td>{user.name}</Td>
+            <Td>{user.email}</Td>
+            <Td>{user.role}</Td>
+            <Td textAlign="right">
+              <Menu>
+                <MenuTrigger>
+                  <IconButton aria-label={`${user.name} options`} icon="ellipsis" />
+                </MenuTrigger>
+                <MenuContent>
+                  <MenuItem icon={<Icon name="arrowRight" />}>Label</MenuItem>
+                  <MenuItem icon={<Icon name="arrowRight" />}>Label</MenuItem>
+                </MenuContent>
+              </Menu>
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  </Box>
+)
+
+// Todo: Make reusable template component?
+const Navbar = (): JSX.Element => {
+  return (
+    <Group as="nav" justifyContent="space-between" paddingBlock={3}>
+      <Group alignItems="center" gap="sm">
+        <IconButton aria-label="Navigate back" icon="arrowLeft" />
+        Page
+      </Group>
+      <Group>
+        <PrimaryButton>Invite</PrimaryButton>
+      </Group>
+    </Group>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,6 +1680,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
+  integrity sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==
+
 "@floating-ui/core@^0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-0.7.3.tgz#d274116678ffae87f6b60e90f88cc4083eefab86"


### PR DESCRIPTION
Skeleton from adding templates. Putting `Templates` in top level of Storybook hierarchy.

Adding a custom navbar for now, that can be improved on and reused if we need it in many templates.

There are a few open questions around the template design, as for example changing typography size on mobile, search button in navbar, highlighted table row, pagination, removed columns on mobile etc.