### PR TITLE
feat(BaseInput): add readonly style

### DIFF
--- a/src/components/controls/inputs/BaseInput/BaseInput.tsx
+++ b/src/components/controls/inputs/BaseInput/BaseInput.tsx
@@ -126,12 +126,21 @@ const StyledInput = styled.input<StyledInputProps>`
   ${({ leftIcon, theme }) => leftIcon && `padding-inline-start: ${4.5 * theme.spacingBase}rem`};
   ${({ rightIcon, theme }) => rightIcon && `padding-inline-end: ${6 * theme.spacingBase}rem`};
 
+  &:read-only {
+    padding-inline-start: 0;
+    background: none;
+  }
+
   &:focus {
     box-shadow: 0px 0px 0px 1px ${({ theme }) => theme.colors.border.selected} inset;
     outline: none;
   }
 
-  &:hover:not(:disabled) {
+  &:focus:read-only {
+    box-shadow: none;
+  }
+
+  &:hover:not(:disabled, :read-only) {
     background: ${({ theme }) => theme.colors.background.tertiary};
   }
 

--- a/src/components/controls/inputs/TextInput/TextInput.stories.tsx
+++ b/src/components/controls/inputs/TextInput/TextInput.stories.tsx
@@ -41,6 +41,18 @@ WithoutLabel.play = async ({ canvasElement }) => {
   await expect(input).not.toHaveErrorMessage()
 }
 
+export const ReadOnly = Template.bind({})
+ReadOnly.args = {
+  label: "Label",
+  value: "Readonly value",
+  readOnly: true,
+}
+ReadOnly.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement)
+  const input = canvas.getByRole("textbox", { name: "Label" })
+  await expect(input).toHaveAttribute("readonly")
+}
+
 export const DefaultValue = Template.bind({})
 DefaultValue.args = {
   ...WithLabel.args,


### PR DESCRIPTION
I disabled the focus state when the input field is set to read only.