### PR TITLE
feat: enable chromatic turbosnap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -26,6 +26,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,6 @@
+const turbosnap = require("vite-plugin-turbosnap")
+const { mergeConfig } = require("vite")
+
 module.exports = {
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
@@ -16,4 +19,10 @@ module.exports = {
     interactionsDebugger: true,
   },
   staticDirs: ["../public"],
+  async viteFinal(config, { configType }) {
+    return mergeConfig(config, {
+      plugins:
+        configType === "PRODUCTION" ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],
+    })
+  },
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "storybook-dark-mode": "2.0.6",
     "typescript": "4.9.5",
     "vite": "4.1.1",
+    "vite-plugin-turbosnap": "1.0.1",
     "vitest": "0.28.5"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15311,6 +15311,11 @@ vite-plugin-istanbul@^3.0.1:
     picocolors "^1.0.0"
     test-exclude "^6.0.0"
 
+vite-plugin-turbosnap@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-turbosnap/-/vite-plugin-turbosnap-1.0.1.tgz#3eacd101defcce59c8526d5162bf13e3513d247a"
+  integrity sha512-isVvISdXZyflIsXYrpTMBnyrtZq92ftohL8/xHi1H0kUwXIFDegqedX1kCKIQ04tjUkphB0cFbGzuvOGVwVTnQ==
+
 vite@4.1.1, "vite@^3.0.0 || ^4.0.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/vite/-/vite-4.1.1.tgz#3b18b81a4e85ce3df5cbdbf4c687d93ebf402e6b"


### PR DESCRIPTION
Before: Each build recreates all snapshots.
https://github.com/einride/ui/actions/runs/4182042035/jobs/7244649970#step:4:80

After: Each build recreates snapshots based on actual changes.
https://github.com/einride/ui/actions/runs/4182087742/jobs/7244750139#step:4:83