### PR TITLE
chore: mirror file structure in storybook and code

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,7 @@ import { mergeConfig } from "vite"
 import turbosnap from "vite-plugin-turbosnap"
 
 export default {
-  stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ["../src/components"],
   addons: [
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",

--- a/src/components/cards/Card/Card.stories.tsx
+++ b/src/components/cards/Card/Card.stories.tsx
@@ -10,7 +10,6 @@ import { Text } from "../../typography/Text/Text"
 import { Card } from "./Card"
 
 const meta = {
-  title: "Cards/Card",
   component: Card,
 } satisfies Meta<typeof Card>
 

--- a/src/components/charts/LinearGauge/LinearGauge.stories.tsx
+++ b/src/components/charts/LinearGauge/LinearGauge.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { LinearGauge } from "./LinearGauge"
 
 const meta = {
-  title: "Charts/LinearGauge",
   component: LinearGauge,
 } satisfies Meta<typeof LinearGauge>
 

--- a/src/components/charts/LinearProgress/LinearProgress.stories.tsx
+++ b/src/components/charts/LinearProgress/LinearProgress.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { LinearProgress } from "./LinearProgress"
 
 const meta = {
-  title: "Charts/LinearProgress",
   component: LinearProgress,
 } satisfies Meta<typeof LinearProgress>
 

--- a/src/components/charts/LinearVerticalProgress/LinearVerticalProgress.stories.tsx
+++ b/src/components/charts/LinearVerticalProgress/LinearVerticalProgress.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { LinearVerticalProgress } from "./LinearVerticalProgress"
 
 const meta = {
-  title: "Charts/LinearVerticalProgress",
   component: LinearVerticalProgress,
 } satisfies Meta<typeof LinearVerticalProgress>
 

--- a/src/components/charts/StepGauge/StepGauge.stories.tsx
+++ b/src/components/charts/StepGauge/StepGauge.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { StepGauge } from "./StepGauge"
 
 const meta = {
-  title: "Charts/StepGauge",
   component: StepGauge,
 } satisfies Meta<typeof StepGauge>
 

--- a/src/components/charts/StepProgress/StepProgress.stories.tsx
+++ b/src/components/charts/StepProgress/StepProgress.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { StepProgress } from "./StepProgress"
 
 const meta = {
-  title: "Charts/StepProgress",
   component: StepProgress,
 } satisfies Meta<typeof StepProgress>
 

--- a/src/components/charts/StepVerticalProgress/StepVerticalProgress.stories.tsx
+++ b/src/components/charts/StepVerticalProgress/StepVerticalProgress.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { StepVerticalProgress } from "./StepVerticalProgress"
 
 const meta = {
-  title: "Charts/StepVerticalProgress",
   component: StepVerticalProgress,
 } satisfies Meta<typeof StepVerticalProgress>
 

--- a/src/components/content/Avatar/Avatar.stories.tsx
+++ b/src/components/content/Avatar/Avatar.stories.tsx
@@ -5,7 +5,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { Avatar } from "./Avatar"
 
 const meta = {
-  title: "Content/Avatar",
   component: Avatar,
 } satisfies Meta<typeof Avatar>
 

--- a/src/components/content/Banner/Banner.stories.tsx
+++ b/src/components/content/Banner/Banner.stories.tsx
@@ -5,7 +5,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { Banner } from "./Banner"
 
 const meta = {
-  title: "Content/Banner",
   component: Banner,
 } satisfies Meta<typeof Banner>
 

--- a/src/components/content/Icon/Icon.stories.tsx
+++ b/src/components/content/Icon/Icon.stories.tsx
@@ -8,7 +8,6 @@ import { Title1 } from "../../typography/Title1/Title1"
 import { Icon, iconNames } from "./Icon"
 
 const meta = {
-  title: "Content/Icon",
   component: Icon,
 } satisfies Meta<typeof Icon>
 

--- a/src/components/content/Logo/Logo.stories.tsx
+++ b/src/components/content/Logo/Logo.stories.tsx
@@ -3,7 +3,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { Logo } from "./Logo"
 
 const meta = {
-  title: "Content/Logo",
   component: Logo,
 } satisfies Meta<typeof Logo>
 

--- a/src/components/content/Tooltip/Tooltip.stories.tsx
+++ b/src/components/content/Tooltip/Tooltip.stories.tsx
@@ -13,7 +13,6 @@ import { Text } from "../../typography/Text/Text"
 import { Tooltip } from "./Tooltip"
 
 const meta = {
-  title: "Content/Tooltip",
   component: Tooltip,
 } satisfies Meta<typeof Tooltip>
 

--- a/src/components/content/UserAccessPoint/UserAccessPoint.stories.tsx
+++ b/src/components/content/UserAccessPoint/UserAccessPoint.stories.tsx
@@ -5,7 +5,6 @@ import { SnapshotWrapper } from "../../../lib/storybook/SnapshotWrapper"
 import { UserAccessPoint } from "./UserAccessPoint"
 
 const meta = {
-  title: "Content/UserAccessPoint",
   component: UserAccessPoint,
 } satisfies Meta<typeof UserAccessPoint>
 


### PR DESCRIPTION
This will base story hierarchy in Storybook on file structure in `src/components` instead of explicitly giving the hierarchy with `title` for each story. The main benefit is that code discovery will be easier since it follows the same structure as Storybook out of the box.

Made the change only for a few components as a start. If you agree, we can make it for all/most. It's still possible to define `title` explicitly for cases where it's needed.