### PR TITLE
fix(Select): set colors

### DIFF
--- a/.changeset/friendly-pans-float.md
+++ b/.changeset/friendly-pans-float.md
@@ -1,0 +1,5 @@
+---
+"@einride/ui": patch
+---
+
+`<Select>`: Set good text and background color on `<option>`s on Ubuntu/Chrome.

--- a/packages/einride-ui/src/components/controls/selects/Select/Select.tsx
+++ b/packages/einride-ui/src/components/controls/selects/Select/Select.tsx
@@ -158,6 +158,11 @@ const StyledSelect = styled.select<StyledSelectProps>`
     color: ${({ theme }) => theme.colors.content.tertiary};
     cursor: not-allowed;
   }
+
+  & option {
+    background: ${({ theme }) => theme.colors.background.primary};
+    color: ${({ theme }) => theme.colors.content.primary};
+  }
 `
 
 const StyledIcon = styled(Icon)`


### PR DESCRIPTION
Fixes browser inconsistencies, where `<option>` is styled in a way that makes it impossible to see the options of Ubuntu Chrome:

![image](https://user-images.githubusercontent.com/44197016/230083596-a1bebfb1-e7bb-472a-8df4-deb99ca0242d.png)
