### PR TITLE
fix: deprecate date components

### DIFF
--- a/.changeset/calm-olives-warn.md
+++ b/.changeset/calm-olives-warn.md
@@ -1,0 +1,5 @@
+---
+"@einride/ui": patch
+---
+
+Deprecate date components in favor of components from @einride/ui-dates.

--- a/packages/einride-ui/src/components/controls/dates/Calendar/Calendar.tsx
+++ b/packages/einride-ui/src/components/controls/dates/Calendar/Calendar.tsx
@@ -27,6 +27,9 @@ export interface CalendarBaseProps {
 
 export type CalendarProps = CalendarBaseProps
 
+/**
+ * @deprecated Use `<DatePicker>` from `@einride/ui-dates` instead.
+ */
 export const Calendar = ({ wrapperProps, ...props }: CalendarProps): React.JSX.Element => {
   return (
     <Box {...wrapperProps}>

--- a/packages/einride-ui/src/components/controls/dates/DatePicker/DatePicker.tsx
+++ b/packages/einride-ui/src/components/controls/dates/DatePicker/DatePicker.tsx
@@ -63,6 +63,9 @@ interface DatePickerWithoutLabelProps {
 export type DatePickerProps = DatePickerBaseProps &
   (DatePickerWithLabelProps | DatePickerWithoutLabelProps)
 
+/**
+ * @deprecated Use `<DatePickerInput>` from `@einride/ui-dates` instead.
+ */
 export const DatePicker = ({
   message,
   messageProps,

--- a/packages/einride-ui/src/components/controls/dates/DateRangePicker/DateRangePicker.tsx
+++ b/packages/einride-ui/src/components/controls/dates/DateRangePicker/DateRangePicker.tsx
@@ -63,6 +63,9 @@ interface DateRangePickerWithoutLabelProps {
 export type DateRangePickerProps = DateRangePickerBaseProps &
   (DateRangePickerWithLabelProps | DateRangePickerWithoutLabelProps)
 
+/**
+ * @deprecated Use `<DateRangePickerInput>` from `@einride/ui-dates` instead.
+ */
 export const DateRangePicker = ({
   message,
   messageProps,

--- a/packages/einride-ui/src/components/controls/dates/RangeCalendar/RangeCalendar.tsx
+++ b/packages/einride-ui/src/components/controls/dates/RangeCalendar/RangeCalendar.tsx
@@ -25,6 +25,9 @@ export interface RangeCalendarProps {
   wrapperProps?: BoxProps
 }
 
+/**
+ * @deprecated Use `<DateRangePicker>` from `@einride/ui-dates` instead.
+ */
 export const RangeCalendar = ({
   wrapperProps,
   ...props


### PR DESCRIPTION
In favor of components from @einride/ui-dates.
