### PR TITLE
fix: add styling and position props to tooltip

### DIFF
--- a/packages/einride-ui/src/components/content/Tooltip/Tooltip.stories.tsx
+++ b/packages/einride-ui/src/components/content/Tooltip/Tooltip.stories.tsx
@@ -171,6 +171,20 @@ export const Align = {
   },
 } satisfies Story
 
+/** You can change the tooltip position with `side`. */
+export const Side = {
+  args: {
+    children: "Hover or focus me and notice that where the tooltip shows up",
+    content: "Tooltip content",
+    side: "right",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const tooltipTrigger = canvas.getByRole("button", { name: Side.args.children })
+    await expect(tooltipTrigger).toHaveAttribute("data-state", "closed")
+  },
+} satisfies Story
+
 export const Pointer = {
   args: {
     ...Basic.args,

--- a/packages/einride-ui/src/components/content/Tooltip/Tooltip.tsx
+++ b/packages/einride-ui/src/components/content/Tooltip/Tooltip.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react"
 import styled from "@emotion/styled"
 import * as RadixTooltip from "@radix-ui/react-tooltip"
-import { ReactNode } from "react"
+import { CSSProperties, ReactNode } from "react"
 import { useTheme } from "../../../hooks/useTheme"
 import { MaxInlineSize, MaxWidth, Width } from "../../../lib/theme/props"
 import { zIndex } from "../../../lib/zIndex"
@@ -37,6 +37,14 @@ export interface TooltipProps {
 
   /** Width of the tooltip. */
   width?: Width
+
+  /** The preferred side on which the tooltip should appear. In case of collision it'll appear on the opposite side. */
+  side?: "top" | "right" | "bottom" | "left"
+
+  /** Props passed to the tooltip content wrapper element */
+  contentWrapperProps?: {
+    style?: Omit<CSSProperties, "rotate" | "scale" | "perspective">
+  }
 }
 
 /** Use tooltips to show additional information. */
@@ -48,6 +56,8 @@ export const Tooltip = ({
   hint,
   openDelayDuration = 0,
   triggerAsChild,
+  side = "top",
+  contentWrapperProps,
   ...props
 }: TooltipProps): React.JSX.Element => {
   const theme = useTheme()
@@ -59,7 +69,13 @@ export const Tooltip = ({
           {children}
         </StyledTooltipTrigger>
         <RadixTooltip.Portal>
-          <StyledTooltipContent align={align} collisionPadding={2 * theme.spacer} sideOffset={5}>
+          <StyledTooltipContent
+            align={align}
+            collisionPadding={2 * theme.spacer}
+            sideOffset={5}
+            side={side}
+            {...contentWrapperProps}
+          >
             <Box {...props}>{content}</Box>
           </StyledTooltipContent>
         </RadixTooltip.Portal>


### PR DESCRIPTION
Added the possibility to style the tooltip content wrapper as well as change it's position