### PR TITLE
fix: resolve zoom/small device issues in tabs component

### DIFF
--- a/.changeset/nervous-mice-report.md
+++ b/.changeset/nervous-mice-report.md
@@ -1,0 +1,5 @@
+---
+"@einride/ui": patch
+---
+
+Resolve zoom/small device issues in tabs component

--- a/packages/einride-ui/src/components/controls/tabs/TabsTrigger.tsx
+++ b/packages/einride-ui/src/components/controls/tabs/TabsTrigger.tsx
@@ -22,12 +22,12 @@ const StyledTabsTrigger = styled(Tabs.Trigger)`
   padding-block-start: ${({ theme }) => 1.625 * theme.spacingBase}rem;
   padding-block-end: ${({ theme }) => 2.375 * theme.spacingBase}rem;
   padding-inline: ${({ theme }) => 2 * theme.spacingBase}rem;
-  box-shadow: inset 0 -0.0625rem 0 ${({ theme }) => theme.colors.border.primary};
+  border-block-end: 0.0625rem solid ${({ theme }) => theme.colors.border.primary};
   line-height: calc(4 / 3);
 
   &[aria-selected="true"] {
     color: ${({ theme }) => theme.colors.content.primary};
-    box-shadow: inset 0 -0.0625rem 0 ${({ theme }) => theme.colors.border.selected};
+    border-block-end: 0.0625rem solid ${({ theme }) => theme.colors.border.selected};
   }
 
   &:hover {
@@ -36,11 +36,14 @@ const StyledTabsTrigger = styled(Tabs.Trigger)`
 
   &:focus-visible {
     outline: none;
-    box-shadow: inset 0 0 0 0.0625rem ${({ theme }) => theme.colors.border.selected};
+    border: 0.0625rem solid ${({ theme }) => theme.colors.border.selected};
+    // The added border takes up extra space. Add negative margins to keep the tab item in it's original size.
+    margin-inline: -0.0625rem;
+    margin-block-start: -0.0625rem;
   }
 
   &:disabled {
     color: ${({ theme }) => theme.colors.content.tertiary};
-    box-shadow: inset 0 -0.0625rem 0 ${({ theme }) => theme.colors.border.primary};
+    border-block-end: 0.0625rem solid ${({ theme }) => theme.colors.border.primary};
   }
 `


### PR DESCRIPTION
**Overview**
The inset shadow effect that is used to display a bottom border for `Tabs` is causing rendering issues on devices with very small screens and in situations where the browser is displaying the content in a "zoomed out" state. In those cases, the box shadow shines through on the sides of the tabs elements giving the impression of a border on the side of each tab.

Testing points to it being a rendering issue in the browser engine that can't be solved by adjusting the box shadow effect or adding some deeper trickery to circumvent the issue. This PR fixes the issue by removing the box shadow and replacing it with a bottom border.

**Note:** I still think that this is only a "developer problem". I can only reproduce this problem by using the Chrome Developer Tools "Device simulator", selecting a mobile device and zooming out in that device simulator. Just by zooming out the browser in normal mode it's not possible for me to reproduce. But the dev that reported this problem says that she gets it on her MacBook and she already did a hardcoded styling override for this in their Saga App so i think we should fix it anyway.