### PR TITLE
chore: replace deprecated testing function

### DIFF
--- a/packages/einride-ui/src/components/controls/inputs/NumberInput/NumberInput.stories.tsx
+++ b/packages/einride-ui/src/components/controls/inputs/NumberInput/NumberInput.stories.tsx
@@ -34,7 +34,7 @@ export const Basic = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -52,7 +52,7 @@ export const WithoutLabel = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -70,7 +70,7 @@ export const ReadOnly = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(ReadOnly.args.value)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
       await expect(input).toHaveAttribute("readonly")
     })
   },
@@ -88,7 +88,7 @@ export const DefaultValue = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(DefaultValue.args.defaultValue)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -110,7 +110,7 @@ export const Controlled = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -127,7 +127,7 @@ export const Message = {
 
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect input to have accessible description based on `message`", async () => {
@@ -148,7 +148,7 @@ export const SuccessMessage = {
 
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect input to have accessible description based on `message`", async () => {
@@ -173,7 +173,7 @@ export const ErrorMessage = {
     })
 
     await step("Expect input to have error message based on `message`", async () => {
-      await expect(input).toHaveErrorMessage(ErrorMessage.args.message)
+      await expect(input).toHaveAccessibleErrorMessage(ErrorMessage.args.message)
     })
   },
 } satisfies Story
@@ -193,7 +193,7 @@ export const Suffix = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect suffix to show", async () => {
@@ -213,7 +213,7 @@ export const Keyboard = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect focus when tabbing", async () => {

--- a/packages/einride-ui/src/components/controls/inputs/SearchInput/SearchInput.stories.tsx
+++ b/packages/einride-ui/src/components/controls/inputs/SearchInput/SearchInput.stories.tsx
@@ -79,7 +79,7 @@ export const Message = {
     const canvas = within(canvasElement)
     const input = canvas.getByRole("textbox", { name: "Search for something fun" })
     await expect(input).toHaveAccessibleDescription("Message.")
-    await expect(input).not.toHaveErrorMessage()
+    await expect(input).not.toHaveAccessibleErrorMessage()
   },
 } satisfies Story
 
@@ -93,7 +93,7 @@ export const SuccessMessage = {
     const canvas = within(canvasElement)
     const input = canvas.getByRole("textbox", { name: "Search for something fun" })
     await expect(input).toHaveAccessibleDescription("Success message.")
-    await expect(input).not.toHaveErrorMessage()
+    await expect(input).not.toHaveAccessibleErrorMessage()
   },
 } satisfies Story
 
@@ -107,7 +107,7 @@ export const ErrorMessage = {
     const canvas = within(canvasElement)
     const input = canvas.getByRole("textbox", { name: "Search for something fun" })
     await expect(input).not.toHaveAccessibleDescription()
-    await expect(input).toHaveErrorMessage("Error message.")
+    await expect(input).toHaveAccessibleErrorMessage("Error message.")
   },
 } satisfies Story
 

--- a/packages/einride-ui/src/components/controls/inputs/TextInput/TextInput.stories.tsx
+++ b/packages/einride-ui/src/components/controls/inputs/TextInput/TextInput.stories.tsx
@@ -34,7 +34,7 @@ export const Basic = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -52,7 +52,7 @@ export const WithoutLabel = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -70,7 +70,7 @@ export const ReadOnly = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(ReadOnly.args.value)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
       await expect(input).toHaveAttribute("readonly")
     })
   },
@@ -88,7 +88,7 @@ export const DefaultValue = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(DefaultValue.args.defaultValue)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -110,7 +110,7 @@ export const Controlled = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -127,7 +127,7 @@ export const Message = {
 
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect input to have accessible description based on `message`", async () => {
@@ -148,7 +148,7 @@ export const SuccessMessage = {
 
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect input to have accessible description based on `message`", async () => {
@@ -173,7 +173,7 @@ export const ErrorMessage = {
     })
 
     await step("Expect input to have error message based on `message`", async () => {
-      await expect(input).toHaveErrorMessage(ErrorMessage.args.message)
+      await expect(input).toHaveAccessibleErrorMessage(ErrorMessage.args.message)
     })
   },
 } satisfies Story
@@ -193,7 +193,7 @@ export const Suffix = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect suffix to show", async () => {
@@ -213,7 +213,7 @@ export const Keyboard = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect focus when tabbing", async () => {

--- a/packages/einride-ui/src/components/controls/inputs/TimeInput/TimeInput.stories.tsx
+++ b/packages/einride-ui/src/components/controls/inputs/TimeInput/TimeInput.stories.tsx
@@ -31,7 +31,7 @@ export const Basic = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -48,7 +48,7 @@ export const WithoutLabel = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -66,7 +66,7 @@ export const ReadOnly = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(ReadOnly.args.value)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
       await expect(input).toHaveAttribute("readonly")
     })
   },
@@ -84,7 +84,7 @@ export const DefaultValue = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue(DefaultValue.args.defaultValue)
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -106,7 +106,7 @@ export const Controlled = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -136,10 +136,10 @@ export const Range = {
     await step("Expect default state", async () => {
       await expect(inputFrom).toHaveValue("")
       await expect(inputFrom).not.toHaveAccessibleDescription()
-      await expect(inputFrom).not.toHaveErrorMessage()
+      await expect(inputFrom).not.toHaveAccessibleErrorMessage()
       await expect(inputTo).toHaveValue("")
       await expect(inputTo).not.toHaveAccessibleDescription()
-      await expect(inputTo).not.toHaveErrorMessage()
+      await expect(inputTo).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies StoryObj
@@ -157,7 +157,7 @@ export const Message = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).toHaveAccessibleDescription(Message.args.message)
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -175,7 +175,7 @@ export const SuccessMessage = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).toHaveAccessibleDescription(SuccessMessage.args.message)
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
   },
 } satisfies Story
@@ -193,7 +193,7 @@ export const ErrorMessage = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).toHaveErrorMessage(ErrorMessage.args.message)
+      await expect(input).toHaveAccessibleErrorMessage(ErrorMessage.args.message)
     })
   },
 } satisfies Story
@@ -209,7 +209,7 @@ export const Keyboard = {
     await step("Expect default state", async () => {
       await expect(input).toHaveValue("")
       await expect(input).not.toHaveAccessibleDescription()
-      await expect(input).not.toHaveErrorMessage()
+      await expect(input).not.toHaveAccessibleErrorMessage()
     })
 
     await step("Expect focus when tabbing", async () => {

--- a/packages/einride-ui/src/components/controls/selects/SearchSelect/SearchSelect.stories.tsx
+++ b/packages/einride-ui/src/components/controls/selects/SearchSelect/SearchSelect.stories.tsx
@@ -201,7 +201,7 @@ export const Message = {
     const canvas = within(canvasElement)
     const input = canvas.getByRole("textbox", { name: "Label" })
     await expect(input).toHaveAccessibleDescription("Message.")
-    await expect(input).not.toHaveErrorMessage()
+    await expect(input).not.toHaveAccessibleErrorMessage()
   },
 } satisfies Story
 

--- a/packages/einride-ui/src/components/controls/textareas/Textarea/Textarea.stories.tsx
+++ b/packages/einride-ui/src/components/controls/textareas/Textarea/Textarea.stories.tsx
@@ -73,7 +73,7 @@ export const Negative = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const textarea = canvas.getByRole("textbox", { name: Negative.args.label })
-    await expect(textarea).toHaveErrorMessage("Negative message")
+    await expect(textarea).toHaveAccessibleErrorMessage("Negative message")
     await expect(textarea).toBeInvalid()
   },
 } satisfies Story


### PR DESCRIPTION
`toHaveErrorMessage` was deprecated a while back: https://github.com/testing-library/jest-dom/pull/503