### PR TITLE
chore: use react-docgen-typescript for improved docs generation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -23,4 +23,7 @@ export default {
         configType === "PRODUCTION" ? [turbosnap({ rootDir: config.root ?? process.cwd() })] : [],
     })
   },
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+  },
 } satisfies StorybookConfig


### PR DESCRIPTION
Before:

<img width="1054" alt="image" src="https://github.com/einride/ui/assets/44197016/eb5629d4-adb5-4f30-b6d2-f35c55aec68b">

After:

<img width="1063" alt="image" src="https://github.com/einride/ui/assets/44197016/6e8f57d9-39bb-4370-9f43-679e24dc6805">
