### PR TITLE
chore(deps): restrict dependabot groups to minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,14 +21,26 @@ updates:
       commitlint:
         patterns:
           - "@commitlint/*"
+        update-types:
+          - "minor"
+          - "patch"
       mantine:
         patterns:
           - "@mantine*"
+        update-types:
+          - "minor"
+          - "patch"
       storybook:
         patterns:
           - "*storybook*"
+        update-types:
+          - "minor"
+          - "patch"
       dev-dependencies: # all other dev dependencies
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       default-days: 7
       semver-major-days: 30


### PR DESCRIPTION
Major-version bumps were being grouped in with patch/minor bumps (e.g. `dependabot/npm_and_yarn/dev-dependencies-a526761b36`, #2794), producing PRs that mixed 40+ safe updates with unrelated breaking changes across ESLint, TypeScript, Storybook, React, and other tooling — CI on that PR failed/hung on multiple independent fronts.

Restricts each dependabot group (`commitlint`, `mantine`, `storybook`, `dev-dependencies`) to `update-types: [minor, patch]`. Major bumps now fall outside every group and open as individual single-package PRs, reviewable and migratable on their own.

Closes #2794 (superseded).